### PR TITLE
Use Mockserver with Dependencies

### DIFF
--- a/clinical-domain-agent/pom.xml
+++ b/clinical-domain-agent/pom.xml
@@ -123,13 +123,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
-      <version>5.14.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+
+      <dependency>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-junit-jupiter</artifactId>
+        <version>5.15.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/research-domain-agent/pom.xml
+++ b/research-domain-agent/pom.xml
@@ -112,13 +112,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
-      <version>5.14.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
       <scope>test</scope>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -45,8 +45,7 @@
 
     <dependency>
       <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
-      <version>5.14.0</version>
+      <artifactId>mockserver-junit-jupiter</artifactId>
     </dependency>
 
     <dependency>

--- a/trust-center-agent/pom.xml
+++ b/trust-center-agent/pom.xml
@@ -126,13 +126,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
-      <version>5.14.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
       <scope>test</scope>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -77,9 +77,7 @@
 
     <dependency>
       <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
-      <version>5.14.0</version>
-      <scope>test</scope>
+      <artifactId>mockserver-junit-jupiter</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
jdk14 logging is optional in this artifact, and not shaded as in the no-dependencies variant. Which can lead to Logback registering a competing slf4 implementation.